### PR TITLE
lib/compressdev: add algo enum 'UNSPECIFIED' to fix warning

### DIFF
--- a/lib/librte_compressdev/rte_comp.h
+++ b/lib/librte_compressdev/rte_comp.h
@@ -41,7 +41,9 @@ enum rte_comp_op_status {
 
 /** Compression Algorithms */
 enum rte_comp_algorithm {
-	RTE_COMP_NULL = 0,
+	RTE_COMP_UNSPECIFIED = 0,
+	/** No Compression algorithm */
+	RTE_COMP_NULL,
 	/**< No compression.
 	 * Pass-through, data is copied unchanged from source buffer to
 	 * destination buffer.

--- a/lib/librte_compressdev/rte_compressdev.h
+++ b/lib/librte_compressdev/rte_compressdev.h
@@ -94,7 +94,7 @@ struct rte_compressdev_capabilities {
 
 /** Macro used at end of comp PMD list */
 #define RTE_COMP_END_OF_CAPABILITIES_LIST() \
-	{ RTE_COMP_ALGO_LIST_END }
+	{ RTE_COMP_UNSPECIFIED }
 
 /**
  * compression device supported feature flags


### PR DESCRIPTION
Adding RTE_COMP_UNSPECIFIED = 0 in algorithm enum to resolve
-Wmissing-field-initializers compiler warning coming at
RTE_COMP_END_OF_CAPABILITIES_LIST()

Signed-off-by: Ashish Gupta <Ashish.Gupta@caviumnetworks.com>
Signed-off-by: Shally Verma <Shally.Verma@caviumnetworks.com>