### PR TITLE
Out of space clarification

### DIFF
--- a/lib/librte_compressdev/rte_comp.h
+++ b/lib/librte_compressdev/rte_comp.h
@@ -39,18 +39,18 @@ enum rte_comp_op_status {
 
 /** Compression Algorithms */
 enum rte_comp_algorithm {
-	RTE_COMP_UNSPECIFIED = 0,
+	RTE_COMP_ALGO_UNSPECIFIED = 0,
 	/** No Compression algorithm */
-	RTE_COMP_NULL,
+	RTE_COMP_ALGO_NULL,
 	/**< No compression.
 	 * Pass-through, data is copied unchanged from source buffer to
 	 * destination buffer.
 	 */
-	RTE_COMP_DEFLATE,
+	RTE_COMP_ALGO_DEFLATE,
 	/**< DEFLATE compression algorithm
 	 * https://tools.ietf.org/html/rfc1951
 	 */
-	RTE_COMP_LZS,
+	RTE_COMP_ALGO_LZS,
 	/**< LZS compression algorithm
 	 * https://tools.ietf.org/html/rfc2395
 	 */
@@ -113,7 +113,7 @@ enum rte_comp_flush_flag {
 	 * ops will be independent of ops processed before this.
 	 */
 	RTE_COMP_FLUSH_FINAL
-	/**< Same as RTE_COMP_FLUSH_FULL but if op.algo is RTE_COMP_DEFLATE
+	/**< Same as RTE_COMP_FLUSH_FULL but if op.algo is RTE_COMP_ALGO_DEFLATE
 	 * then bfinal bit is set in the last block.
 	 */
 };

--- a/lib/librte_compressdev/rte_comp.h
+++ b/lib/librte_compressdev/rte_comp.h
@@ -32,8 +32,16 @@ enum rte_comp_op_status {
 	/**< Error handling operation */
 	RTE_COMP_OP_STATUS_INVALID_STATE,
 	/**< Operation is invoked in invalid state */
-	RTE_COMP_OP_STATUS_OUT_OF_SPACE,
-	/**< Output buffer ran out of space before operation completed */
+	RTE_COMP_OP_STATUS_OUT_OF_SPACE_TERMINATED,
+	/**< Output buffer ran out of space before operation completed.
+	 * Error case. Application must resubmit all data with a larger
+	 * output buffer.
+	 */
+	RTE_COMP_OP_STATUS_OUT_OF_SPACE_RECOVERABLE,
+	/**< Output buffer ran out of space before operation completed, but this
+	 * is not an error case. Output data up to op.produced can be used and
+	 * next op in the stream should continue on from op.consumed+1.
+	 */
 };
 
 

--- a/lib/librte_compressdev/rte_compressdev.c
+++ b/lib/librte_compressdev/rte_compressdev.c
@@ -648,7 +648,7 @@ rte_compressdev_info_get(uint8_t dev_id, struct rte_compressdev_info *dev_info)
 
 int __rte_experimental
 rte_compressdev_private_xform_create(uint8_t dev_id,
-		struct rte_comp_xform *xform,
+		const struct rte_comp_xform *xform,
 		void **priv_xform)
 {
 	struct rte_compressdev *dev;
@@ -696,7 +696,7 @@ rte_compressdev_private_xform_free(uint8_t dev_id, void *priv_xform)
 
 int __rte_experimental
 rte_compressdev_stream_create(uint8_t dev_id,
-		struct rte_comp_xform *xform,
+		const struct rte_comp_xform *xform,
 		void **stream)
 {
 	struct rte_compressdev *dev;

--- a/lib/librte_compressdev/rte_compressdev.c
+++ b/lib/librte_compressdev/rte_compressdev.c
@@ -62,8 +62,8 @@ struct rte_compressdev_global *rte_compressdev_globals = &compressdev_globals;
  */
 const char *
 rte_comp_algorithm_strings[] = {
-	[RTE_COMP_DEFLATE]		= "deflate",
-	[RTE_COMP_LZS]			= "lzs"
+	[RTE_COMP_ALGO_DEFLATE]		= "deflate",
+	[RTE_COMP_ALGO_LZS]		= "lzs"
 };
 
 

--- a/lib/librte_compressdev/rte_compressdev.h
+++ b/lib/librte_compressdev/rte_compressdev.h
@@ -610,7 +610,8 @@ rte_compressdev_enqueue_burst(uint8_t dev_id, uint16_t qp_id,
  *
  */
 int __rte_experimental
-rte_compressdev_stream_create(uint8_t dev_id, struct rte_comp_xform *xform,
+rte_compressdev_stream_create(uint8_t dev_id,
+		const struct rte_comp_xform *xform,
 		void **stream);
 
 /**
@@ -657,7 +658,7 @@ rte_compressdev_stream_free(uint8_t dev_id, void *stream);
  */
 int __rte_experimental
 rte_compressdev_private_xform_create(uint8_t dev_id,
-		struct rte_comp_xform *xform,
+		const struct rte_comp_xform *xform,
 		void **private_xform);
 
 /**

--- a/lib/librte_compressdev/rte_compressdev.h
+++ b/lib/librte_compressdev/rte_compressdev.h
@@ -94,7 +94,7 @@ struct rte_compressdev_capabilities {
 
 /** Macro used at end of comp PMD list */
 #define RTE_COMP_END_OF_CAPABILITIES_LIST() \
-	{ RTE_COMP_UNSPECIFIED }
+	{ RTE_COMP_ALGO_UNSPECIFIED }
 
 /**
  * compression device supported feature flags

--- a/lib/librte_compressdev/rte_compressdev.h
+++ b/lib/librte_compressdev/rte_compressdev.h
@@ -503,7 +503,20 @@ struct rte_compressdev *rte_compressdevs;
  * The rte_compressdev_dequeue_burst() function does not provide any error
  * notification to avoid the corresponding overhead.
  *
- * Note: operation ordering is not maintained within the queue pair.
+ * @note: operation ordering is not maintained within the queue pair.
+ *
+ * @note: In case op status = OUT_OF_SPACE_TERMINATED, op.consumed=0 and the
+ * op must be resubmitted with the same input data and a larger output buffer.
+ * op.produced is usually 0, but in decompression cases a PMD may return > 0
+ * and the application may find it useful to inspect that data.
+ * This status is only returned on STATELESS ops.
+ *
+ * @note: In case op status = OUT_OF_SPACE_RECOVERABLE, op.produced can be used
+ * and next op in stream should continue on from op.consumed+1 with a fresh
+ * output buffer.
+ * Consumed=0, produced=0 is an unusual but allowed case. There may be useful
+ * state/history stored in the PMD, even though no output was produced yet.
+ *
  *
  * @param dev_id
  *   Compress device identifier
@@ -553,7 +566,7 @@ rte_compressdev_dequeue_burst(uint8_t dev_id, uint16_t qp_id,
  * as the size of the output data is different to the size of the input data.
  *
  * @note The flush flag only applies to operations which return SUCCESS.
- * In OUT_OF_SPACE case whether STATEFUL or STATELESS, data in dest buffer
+ * In OUT_OF_SPACE cases whether STATEFUL or STATELESS, data in dest buffer
  * is as if flush flag was FLUSH_NONE.
  * @note flush flag only applies in compression direction. It has no meaning
  * for decompression.

--- a/lib/librte_compressdev/rte_compressdev.h
+++ b/lib/librte_compressdev/rte_compressdev.h
@@ -272,6 +272,10 @@ struct rte_compressdev_config {
 	/**< Socket on which to allocate resources */
 	uint16_t nb_queue_pairs;
 	/**< Total number of queue pairs to configure on a device */
+	uint16_t max_nb_priv_xforms;
+	/**< Max number of private_xforms which will be created on the device */
+	uint16_t max_nb_streams;
+	/**< Max number of streams which will be created on the device */
 };
 
 /**

--- a/lib/librte_compressdev/rte_compressdev_pmd.h
+++ b/lib/librte_compressdev/rte_compressdev_pmd.h
@@ -245,7 +245,7 @@ typedef uint32_t (*compressdev_queue_pair_count_t)(struct rte_compressdev *dev);
  *  - Returns -ENOMEM if the private stream could not be allocated.
  */
 typedef int (*compressdev_stream_create_t)(struct rte_compressdev *dev,
-		struct rte_comp_xform *xform, void **stream);
+		const struct rte_comp_xform *xform, void **stream);
 
 /**
  * Free driver private stream data.
@@ -282,7 +282,7 @@ typedef int (*compressdev_stream_free_t)(struct rte_compressdev *dev,
  *  - Returns -ENOMEM if the private_xform could not be allocated.
  */
 typedef int (*compressdev_private_xform_create_t)(struct rte_compressdev *dev,
-		struct rte_comp_xform *xform, void **private_xform);
+		const struct rte_comp_xform *xform, void **private_xform);
 
 /**
  * Free driver private_xform data.


### PR DESCRIPTION
Hi all,

I’m trying to describe what we agreed re OUT_OF_SPACE (on 16/2):
>> [Fiona] That's not quite how I understood it. Can it be simpler and only following cases?
>> a. stateless with flush = full/final, no stream pointer provided , PMD can return TERMINATED i.e. user
>>     has to start all over again, it's a failure (as in current definition).
>>     consumed = 0, produced=amount of data produced. This is usually 0, but in decompression
>>     case a PMD may return > 0 and application may find it useful to inspect that data.
>> b. stateless with flush = full/final, stream pointer provided, here it's up to PMD to return either
>>     TERMINATED or RECOVERABLE depending upon its ability (note if Recoverable, then PMD will maintain
>>     states in stream pointer)
>> c. stateful with flush = any, stream pointer always there, PMD will return RECOVERABLE.
>>     op.produced can be used and next op in stream should continue on from op.consumed+1.
>>     Consumed=0, produced=0 is an unusual but allowed case. I'm not sure if it could ever happen, but
>>     no need to change state to TERMINATED in this case. There may be useful state/history
>>     stored in the PMD, even though no output produced yet.
>[Ahmed] Agreed
[Shally] Sounds good.

(a) and (c) are ok - covered in this patch.
I was going to write this to cover (b), but can’t see how it can work?
 * Typically OUT_OF_SPACE_RECOVERABLE is only returned on STATEFUL ops, however
 * a PMD may return this on a STATELESS op if it is capable of continuing on.
 * In this case it must be using a NOT_SHAREABLE private_xform in which it
 * stored the history and state, so enabling it to continue.

Can this work? 
How does the PMD know how to relate the next op to the history and state of the last op?
And couldn't the appl attach the private_xform to some other op, once the first op is complete? And then the history would be overwritten - i.e would the application need to know to NOT re-use the private_xform in this case?
But then what if the appl doesn't try to recover and resubmits from the start how will the PMD know NOT to use the history?
And when will the history get cleared?

Or would it work like a flush full? i.e. the PMD produces output which is decompressible, i.e. finishes the deflate block, no history or state stored, it can continue from consumed+1 but next output will not depend on previous. Like 2 sequential stateless ops on sequential data. No need for PMD to be aware of the link between the 2 ops.
This sounds like it could work.

I’ll leave out for v2 – we can add in v3 if there’s a valid case.
